### PR TITLE
feat: add core molecule graph and SMILES io

### DIFF
--- a/packages/chem-core/src/Atom.ts
+++ b/packages/chem-core/src/Atom.ts
@@ -1,0 +1,11 @@
+export class Atom {
+  constructor(
+    public z: number,
+    public isotope = 0,
+    public charge = 0,
+    public valenceSlots = 0,
+    public mapIdx?: number,
+  ) {}
+}
+
+export type AtomIndex = number;

--- a/packages/chem-core/src/Bond.ts
+++ b/packages/chem-core/src/Bond.ts
@@ -1,0 +1,13 @@
+import type { AtomIndex } from './Atom';
+
+export type BondOrder = 1 | 2 | 3 | 'aromatic';
+export type BondStereo = 'up' | 'down' | 'wavy' | null;
+
+export class Bond {
+  constructor(
+    public a1: AtomIndex,
+    public a2: AtomIndex,
+    public order: BondOrder,
+    public stereo: BondStereo = null,
+  ) {}
+}

--- a/packages/chem-core/src/Molecule.ts
+++ b/packages/chem-core/src/Molecule.ts
@@ -1,0 +1,102 @@
+import { Atom, AtomIndex } from './Atom';
+import { Bond, BondOrder, BondStereo } from './Bond';
+
+export class Molecule {
+  atoms: Atom[] = [];
+  bonds: Bond[] = [];
+
+  addAtom(atom: Atom): AtomIndex {
+    this.atoms.push(atom);
+    return this.atoms.length - 1;
+  }
+
+  addBond(a1: AtomIndex, a2: AtomIndex, order: BondOrder = 1, stereo: BondStereo = null): number {
+    const bond = new Bond(a1, a2, order, stereo);
+    this.bonds.push(bond);
+    return this.bonds.length - 1;
+  }
+
+  removeBond(index: number): void {
+    this.bonds.splice(index, 1);
+  }
+
+  removeAtom(index: AtomIndex): void {
+    this.atoms.splice(index, 1);
+    this.bonds = this.bonds
+      .filter((b) => b.a1 !== index && b.a2 !== index)
+      .map((b) => {
+        const a1 = b.a1 > index ? b.a1 - 1 : b.a1;
+        const a2 = b.a2 > index ? b.a2 - 1 : b.a2;
+        return new Bond(a1, a2, b.order, b.stereo);
+      });
+  }
+
+  getNeighbors(index: AtomIndex): AtomIndex[] {
+    const result: AtomIndex[] = [];
+    for (const b of this.bonds) {
+      if (b.a1 === index) result.push(b.a2);
+      else if (b.a2 === index) result.push(b.a1);
+    }
+    return result;
+  }
+
+  fragments(): AtomIndex[][] {
+    const visited = new Set<AtomIndex>();
+    const frags: AtomIndex[][] = [];
+    for (let i = 0; i < this.atoms.length; i++) {
+      if (visited.has(i)) continue;
+      const stack = [i];
+      const frag: AtomIndex[] = [];
+      visited.add(i);
+      while (stack.length) {
+        const a = stack.pop()!;
+        frag.push(a);
+        for (const n of this.getNeighbors(a)) {
+          if (!visited.has(n)) {
+            visited.add(n);
+            stack.push(n);
+          }
+        }
+      }
+      frags.push(frag);
+    }
+    return frags;
+  }
+
+  clone(): Molecule {
+    const m = new Molecule();
+    m.atoms = this.atoms.map(
+      (a) => new Atom(a.z, a.isotope, a.charge, a.valenceSlots, a.mapIdx),
+    );
+    m.bonds = this.bonds.map((b) => new Bond(b.a1, b.a2, b.order, b.stereo));
+    return m;
+  }
+
+  private canonicalForm(): string {
+    const atoms = this.atoms.map((a, idx) => ({
+      idx,
+      label: `${a.z}:${a.charge}`,
+    }));
+    atoms.sort((a, b) => a.label.localeCompare(b.label));
+    const map = new Map<number, number>();
+    atoms.forEach((a, i) => map.set(a.idx, i));
+    const bonds = this.bonds
+      .map((b) => {
+        let a1 = map.get(b.a1)!;
+        let a2 = map.get(b.a2)!;
+        if (a1 > a2) [a1, a2] = [a2, a1];
+        return { a1, a2, order: b.order };
+      })
+      .sort((x, y) => x.a1 - y.a1 || x.a2 - y.a2 || (x.order as number) - (y.order as number));
+    const atomList = atoms.map((a) => a.label).join(',');
+    const bondList = bonds.map((b) => `${b.a1}-${b.a2}-${b.order}`).join(',');
+    return `${atomList}|${bondList}`;
+  }
+
+  equalsIso(other: Molecule): boolean {
+    return this.canonicalForm() === other.canonicalForm();
+  }
+}
+
+export { Atom } from './Atom';
+export { Bond } from './Bond';

--- a/packages/chem-core/src/PeriodicTable.ts
+++ b/packages/chem-core/src/PeriodicTable.ts
@@ -1,0 +1,41 @@
+export interface ElementInfo {
+  symbol: string;
+  z: number;
+  covalentRadius: number;
+  valences: number[];
+}
+
+const DATA: Record<string, ElementInfo> = {
+  B: { symbol: 'B', z: 5, covalentRadius: 0.84, valences: [3] },
+  C: { symbol: 'C', z: 6, covalentRadius: 0.76, valences: [4] },
+  N: { symbol: 'N', z: 7, covalentRadius: 0.71, valences: [3, 5] },
+  O: { symbol: 'O', z: 8, covalentRadius: 0.66, valences: [2] },
+  F: { symbol: 'F', z: 9, covalentRadius: 0.57, valences: [1] },
+  P: { symbol: 'P', z: 15, covalentRadius: 1.07, valences: [3, 5] },
+  S: { symbol: 'S', z: 16, covalentRadius: 1.05, valences: [2, 4, 6] },
+  Cl: { symbol: 'Cl', z: 17, covalentRadius: 1.02, valences: [1] },
+  Br: { symbol: 'Br', z: 35, covalentRadius: 1.2, valences: [1] },
+  I: { symbol: 'I', z: 53, covalentRadius: 1.39, valences: [1] },
+};
+
+const BY_Z: Record<number, ElementInfo> = Object.fromEntries(
+  Object.values(DATA).map((e) => [e.z, e]),
+);
+
+export class PeriodicTable {
+  static bySymbol(symbol: string): ElementInfo {
+    const e = DATA[symbol];
+    if (!e) throw new Error(`Unknown element: ${symbol}`);
+    return e;
+  }
+
+  static byAtomicNumber(z: number): ElementInfo {
+    const e = BY_Z[z];
+    if (!e) throw new Error(`Unknown atomic number: ${z}`);
+    return e;
+  }
+
+  static symbol(z: number): string {
+    return this.byAtomicNumber(z).symbol;
+  }
+}

--- a/packages/chem-core/src/ValenceRules.ts
+++ b/packages/chem-core/src/ValenceRules.ts
@@ -1,0 +1,28 @@
+import type { Molecule } from './Molecule';
+import { PeriodicTable } from './PeriodicTable';
+
+export class ValenceRules {
+  static sanitize(mol: Molecule): void {
+    mol.atoms.forEach((atom, idx) => {
+      const element = PeriodicTable.byAtomicNumber(atom.z);
+      const used = mol.bonds.reduce((sum, b) => {
+        if (b.a1 === idx || b.a2 === idx) {
+          return sum + (b.order === 'aromatic' ? 1 : b.order);
+        }
+        return sum;
+      }, 0);
+      const allowed = element.valences.map((v) => v + atom.charge);
+      const maxAllowed = Math.max(...allowed);
+      let ok = false;
+      if (atom.charge !== 0) {
+        ok = allowed.includes(used);
+      } else {
+        ok = used <= maxAllowed;
+      }
+      if (!ok) {
+        throw new Error(`Impossible valence for ${element.symbol}`);
+      }
+      atom.valenceSlots = maxAllowed - used;
+    });
+  }
+}

--- a/packages/chem-core/src/index.ts
+++ b/packages/chem-core/src/index.ts
@@ -1,1 +1,5 @@
-export const corePlaceholder = true;
+export * from './Atom';
+export * from './Bond';
+export * from './Molecule';
+export * from './PeriodicTable';
+export * from './ValenceRules';

--- a/packages/chem-io/package.json
+++ b/packages/chem-io/package.json
@@ -6,5 +6,8 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "test": "vitest --passWithNoTests"
+  },
+  "dependencies": {
+    "@chem/core": "workspace:*"
   }
 }

--- a/packages/chem-io/src/SmilesParser.ts
+++ b/packages/chem-io/src/SmilesParser.ts
@@ -1,0 +1,85 @@
+import {
+  Atom,
+  Molecule,
+  PeriodicTable,
+  ValenceRules,
+} from '@chem/core';
+
+export class SmilesParser {
+  parse(smiles: string): Molecule {
+    const mol = new Molecule();
+    const stack: number[] = [];
+    const ring: Map<number, number> = new Map();
+    let current: number | null = null;
+    let i = 0;
+
+    const readAtom = (): number => {
+      if (smiles[i] === '[') {
+        const end = smiles.indexOf(']', i);
+        if (end === -1) throw new Error('Unclosed bracket');
+        const inside = smiles.slice(i + 1, end);
+        const m = inside.match(/^(Cl|Br|[BCNOFPSI])([+-])?$/);
+        if (!m) throw new Error(`Unsupported atom: ${inside}`);
+        const sym = m[1];
+        const charge = m[2] === '+' ? 1 : m[2] === '-' ? -1 : 0;
+        const atom = new Atom(PeriodicTable.bySymbol(sym).z, 0, charge);
+        const idx = mol.addAtom(atom);
+        i = end + 1;
+        return idx;
+      }
+      let sym: string | null = null;
+      if (smiles.startsWith('Cl', i) || smiles.startsWith('Br', i)) {
+        sym = smiles.slice(i, i + 2);
+        i += 2;
+      } else {
+        sym = smiles[i];
+        i += 1;
+      }
+      const allowed = ['B', 'C', 'N', 'O', 'F', 'P', 'S', 'Cl', 'Br', 'I'];
+      if (!allowed.includes(sym)) throw new Error(`Unsupported atom: ${sym}`);
+      const atom = new Atom(PeriodicTable.bySymbol(sym).z);
+      const idx = mol.addAtom(atom);
+      return idx;
+    };
+
+    while (i < smiles.length) {
+      const ch = smiles[i];
+      if (ch === '(') {
+        if (current === null) throw new Error('Branch with no starting atom');
+        stack.push(current);
+        i++;
+        continue;
+      }
+      if (ch === ')') {
+        current = stack.pop() ?? null;
+        i++;
+        continue;
+      }
+      if (ch === '[' || /[A-Za-z]/.test(ch)) {
+        const idx = readAtom();
+        if (current !== null) mol.addBond(current, idx, 1);
+        current = idx;
+        continue;
+      }
+      if (/[1-9]/.test(ch)) {
+        const d = parseInt(ch, 10);
+        if (current === null) throw new Error('Ring digit with no atom');
+        const other = ring.get(d);
+        if (other === undefined) ring.set(d, current);
+        else {
+          mol.addBond(current, other, 1);
+          ring.delete(d);
+        }
+        i++;
+        continue;
+      }
+      throw new Error(`Unexpected character: ${ch}`);
+    }
+
+    if (stack.length) throw new Error('Unclosed branch');
+    if (ring.size) throw new Error('Unclosed ring');
+
+    ValenceRules.sanitize(mol);
+    return mol;
+  }
+}

--- a/packages/chem-io/src/SmilesWriter.ts
+++ b/packages/chem-io/src/SmilesWriter.ts
@@ -1,0 +1,72 @@
+import { Molecule, PeriodicTable } from '@chem/core';
+
+interface RingDigitInfo {
+  neighbor: number;
+  digit: number;
+}
+
+function assignRingDigits(mol: Molecule) {
+  const digits = new Map<number, RingDigitInfo[]>();
+  const skip = new Set<string>();
+  let next = 1;
+  const visited = new Set<number>();
+
+  const dfs = (idx: number, parent: number | null) => {
+    visited.add(idx);
+    for (const n of mol.getNeighbors(idx)) {
+      if (n === parent) continue;
+      if (!visited.has(n)) {
+        dfs(n, idx);
+      } else if (idx < n) {
+        const key = `${idx}-${n}`;
+        if (!skip.has(key)) {
+          const digit = next++;
+          if (!digits.has(idx)) digits.set(idx, []);
+          if (!digits.has(n)) digits.set(n, []);
+          digits.get(idx)!.push({ neighbor: n, digit });
+          digits.get(n)!.push({ neighbor: idx, digit });
+          skip.add(key);
+        }
+      }
+    }
+  };
+  if (mol.atoms.length > 0) dfs(0, null);
+  return { digits, skip };
+}
+
+export class SmilesWriter {
+  static write(mol: Molecule): string {
+    if (mol.atoms.length === 0) return '';
+    const { digits, skip } = assignRingDigits(mol);
+    const visited = new Set<number>();
+
+    const atomToString = (idx: number): string => {
+      const atom = mol.atoms[idx];
+      const sym = PeriodicTable.symbol(atom.z);
+      let s = sym;
+      if (atom.charge !== 0) s = `[${sym}${atom.charge > 0 ? '+' : '-'}]`;
+      const d = digits.get(idx) ?? [];
+      if (d.length) s += d.map((r) => r.digit).join('');
+      return s;
+    };
+
+    const dfsWrite = (idx: number, parent: number | null): string => {
+      visited.add(idx);
+      let result = atomToString(idx);
+      let neighbors = mol.getNeighbors(idx).filter((n) => n !== parent);
+      neighbors = neighbors.filter((n) => !(idx < n && skip.has(`${idx}-${n}`)));
+      neighbors.sort((a, b) => a - b);
+      const chain = neighbors.pop();
+      for (const n of neighbors) {
+        if (visited.has(n)) continue;
+        result += `(${dfsWrite(n, idx)})`;
+      }
+      if (chain !== undefined && !visited.has(chain)) {
+        result += dfsWrite(chain, idx);
+      }
+      return result;
+    };
+
+    return dfsWrite(0, null);
+  }
+}

--- a/packages/chem-io/src/index.ts
+++ b/packages/chem-io/src/index.ts
@@ -1,1 +1,2 @@
-export const ioPlaceholder = true;
+export * from './SmilesParser';
+export * from './SmilesWriter';

--- a/packages/chem-io/test/smiles.test.ts
+++ b/packages/chem-io/test/smiles.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { SmilesParser, SmilesWriter } from '../src';
+
+const roundTrip = (s: string) => {
+  const parser = new SmilesParser();
+  const mol = parser.parse(s);
+  const out = SmilesWriter.write(mol);
+  expect(out).toBe(s);
+};
+
+describe('SMILES parse/write', () => {
+  it('isobutane', () => roundTrip('CC(C)C'));
+  it('ethanol', () => roundTrip('CCO'));
+  it('cyclohexane', () => roundTrip('C1CCCCC1'));
+  it('invalid valence', () => {
+    const parser = new SmilesParser();
+    expect(() => parser.parse('C[O+]')).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- implement Atom, Bond, Molecule graph with valence rules and periodic data
- add basic SMILES parser and writer with tests

## Testing
- `pnpm -C packages/chem-core test --run`
- `pnpm -C packages/chem-io test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a236da21248321891d02b712d1a6e8