### PR TITLE
fix: use classic React runtime

### DIFF
--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -4,7 +4,7 @@ import electron from 'vite-plugin-electron';
 
 export default defineConfig({
   plugins: [
-    react(),
+    react({ jsxRuntime: 'classic' }),
     electron({
       main: {
         entry: 'src/main.ts',

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -2,5 +2,5 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react({ jsxRuntime: 'classic' })],
 });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "eslint-config-prettier": "^9.0.0",
     "jsdom": "^26.1.0",
     "prettier": "^3.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "typescript": "^5.2.0",
     "vite": "^4.4.0",
     "vite-plugin-electron": "^0.11.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,12 @@ importers:
       prettier:
         specifier: ^3.0.0
         version: 3.6.2
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
       typescript:
         specifier: ^5.2.0
         version: 5.9.2

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -7,7 +7,7 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "jsx": "react-jsx",
+    "jsx": "react",
     "resolveJsonModule": true,
     "outDir": "dist",
     "declaration": true


### PR DESCRIPTION
## Summary
- switch TypeScript to classic JSX transform
- configure both Vite apps to use classic React runtime

## Testing
- `pnpm -r build`
- `CI=1 pnpm test`
- `pnpm lint`
- `timeout 5 pnpm dev`

------
https://chatgpt.com/codex/tasks/task_e_68a23f173df883219046ef6b3b4bf494